### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ jobs:
   draft_release:
     name: Release Drafter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Run release-drafter
         uses: release-drafter/release-drafter@v6.1.0


### PR DESCRIPTION
Potential fix for [https://github.com/MrFjellstad/norgesnett/security/code-scanning/2](https://github.com/MrFjellstad/norgesnett/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the `release-drafter` action primarily requires read access to repository contents and possibly write access to pull requests for labeling, we will set the permissions to `contents: read` and `pull-requests: write`. This ensures the workflow has only the minimal permissions necessary to function.

The `permissions` block will be added at the job level (`draft_release`) to scope the permissions specifically to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
