### PR TITLE
Fix entity attribute naming and API client defaults

### DIFF
--- a/custom_components/norgesnett/api.py
+++ b/custom_components/norgesnett/api.py
@@ -38,7 +38,7 @@ class NorgesnettApiClient:
             },
         )
         apiKey = auth_info["apiKey"]
-        _LOGGER.debug("apiKey:", apiKey)
+        _LOGGER.debug("apiKey: %s", apiKey)
         return auth_info
 
     async def async_get_data(self) -> dict:
@@ -78,7 +78,11 @@ class NorgesnettApiClient:
     #     await self.api_wrapper("patch", url, data={"title": value}, headers=HEADERS)
 
     async def api_wrapper(
-        self, method: str, url: str, data: dict = {}, headers: dict = {}
+        self,
+        method: str,
+        url: str,
+        data: dict | None = None,
+        headers: dict | None = None,
     ) -> dict:
         """Get information from the API."""
         _LOGGER.info("api_wrapper: %s %s", method, url)

--- a/custom_components/norgesnett/entity.py
+++ b/custom_components/norgesnett/entity.py
@@ -26,8 +26,8 @@ class NorgesnettEntity(CoordinatorEntity):
         }
 
     @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
+    def extra_state_attributes(self):
+        """Return the extra state attributes."""
         return {
             "attribution": ATTRIBUTION,
             "id": str(self.coordinator.data.get("id")),


### PR DESCRIPTION
## Summary
- use extra_state_attributes instead of deprecated device_state_attributes for entities
- guard API client against mutable defaults and improve debug logging

## Testing
- `pip install -r requirements_dev.txt` *(fails: Could not find a version that satisfies the requirement homeassistant)*
- `pre-commit run --files custom_components/norgesnett/entity.py custom_components/norgesnett/api.py` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_6894b38cd4b0832ea8333cff06137459