### PR TITLE
Fix spelling in README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Discord][discord-shield]][discord]
 [![Community Forum][forum-shield]][forum]
 
-**Integrasjon for å hente ut informasjon fra nettlevrandøren Norgesnett.**
+**Integrasjon for å hente ut informasjon fra nettleverandøren Norgesnett.**
 Den er tilpasset et målerpunkt, api'et til Norgesnett vil hente ut informasjon fra flere.
 
 Jeg har bare et målerpunkt så jeg har ikke sett for mye på hvordan det bør løses om man har fler.


### PR DESCRIPTION
## Summary
- correct Norwegian spelling in README introduction

## Testing
- `codespell --version` *(fails: command not found)*
- `pip install codespell` *(fails: Could not find a version that satisfies the requirement codespell)*
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6894ba877054832ea87e487fa91fec78