### PR TITLE
Include switch platform in Norgesnett integration

### DIFF
--- a/custom_components/norgesnett/const.py
+++ b/custom_components/norgesnett/const.py
@@ -19,8 +19,7 @@ BINARY_SENSOR_DEVICE_CLASS = "connectivity"
 BINARY_SENSOR = "binary_sensor"
 SENSOR = "sensor"
 SWITCH = "switch"
-# PLATFORMS = [BINARY_SENSOR, SENSOR, SWITCH]
-PLATFORMS = [SENSOR]
+PLATFORMS = [BINARY_SENSOR, SENSOR, SWITCH]
 
 
 # Configuration and options


### PR DESCRIPTION
## Summary
- load switch platform alongside other platforms

## Testing
- `pytest -q` *(fails: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_6894bf113dcc832eb6288490eb860fc2